### PR TITLE
Add a template file we can use to overwrite the CamelJBang.java file

### DIFF
--- a/CamelJBang.tmpl
+++ b/CamelJBang.tmpl
@@ -19,9 +19,9 @@
 
 //JAVA 17+
 //REPOS central=https://repo1.maven.org/maven2,redhat.ga=https://maven.repository.redhat.com/ga/
-//DEPS org.apache.camel:camel-bom:${{camel.jbang.version}:4.10.3.redhat-00005}@pom
-//DEPS org.apache.camel:camel-jbang-core:${{camel.jbang.version}:4.10.3}
-//DEPS org.apache.camel.kamelets:camel-kamelets:${{camel-kamelets.version}:4.10.3.redhat-00003}
+//DEPS org.apache.camel:camel-bom:${camel.jbang.version:camel-version}@pom
+//DEPS org.apache.camel:camel-jbang-core:${camel.jbang.version:camel-community-version}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${camel-kamelets.version:camel-kamelets-version}
 
 package main;
 

--- a/CamelJBang.tmpl
+++ b/CamelJBang.tmpl
@@ -1,0 +1,39 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//JAVA 17+
+//REPOS central=https://repo1.maven.org/maven2,redhat.ga=https://maven.repository.redhat.com/ga/
+//DEPS org.apache.camel:camel-bom:${{camel.jbang.version}:4.10.3.redhat-00005}@pom
+//DEPS org.apache.camel:camel-jbang-core:${{camel.jbang.version}:4.10.3}
+//DEPS org.apache.camel.kamelets:camel-kamelets:${{camel-kamelets.version}:4.10.3.redhat-00003}
+
+package main;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+
+/**
+ * Main to run CamelJBang
+ */
+public class CamelJBang {
+
+    public static void main(String... args) {
+        CamelJBangMain.run(args);
+    }
+
+}


### PR DESCRIPTION
I think we need a template file that serves as the source given that we're going to be overwriting the CamelJBang.java file constantly.

We probably want to tokenize the maven repositories as well at some point but I think that's future work when we work out the dev / ea repository stuff.