### PR TITLE
tests: add camel run with parameter runtime=quarkus version check

### DIFF
--- a/.github/actions/update-versions/src/test/java/com/redhat/camel/cli/test/UpdateVersionsTest.java
+++ b/.github/actions/update-versions/src/test/java/com/redhat/camel/cli/test/UpdateVersionsTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -36,7 +37,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
+import org.cliassured.Await;
 import org.cliassured.CliAssured;
+import org.cliassured.CommandProcess;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand.ResetType;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -919,6 +922,32 @@ public class UpdateVersionsTest {
                 .hasLinesMatching("[BUILD SUCCESS]")
                 .execute()
                 .assertSuccess();
+
+        testRun(platformVersion, testDir);
+    }
+
+    static void testRun(String platformVersion, Path testDir) {
+        // Derive the expected Quarkus major.minor prefix from the platform version.
+        final String[] segments = platformVersion.split("\\.");
+        final String quarkusMajorMinorPrefix = segments[0] + "." + segments[1] + ".";
+
+        final Await.LineAwait<String> awaitQuarkusStarted = Await
+                .lineContaining("Apache Camel Quarkus " + quarkusMajorMinorPrefix);
+
+        try (CommandProcess proc = CliAssured.command("camel", "run", "--runtime=quarkus", "Hello.java")
+                .cd(testDir)
+                .autoCloseForcibly()
+                .stderrToStdout()
+                .then()
+                .stdout()
+                .await(awaitQuarkusStarted)
+                .log()
+                .start()) {
+
+            // Wait up to 5 minutes for Quarkus to start (first Maven build downloads dependencies)
+            final String matchedLine = awaitQuarkusStarted.await(Duration.ofMinutes(5));
+            log.info("camel run --runtime=quarkus started: {}", matchedLine);
+        }
     }
 
     static String findCamelVersion(Path camelJbangPath) {


### PR DESCRIPTION
CEQ-13468

Add testRun() to endToEndJbang() to verify that camel run --runtime=quarkus starts the expected Quarkus platform version.

The test starts the process, awaits the 'Apache Camel Quarkus <major.minor>' startup log line, asserts it matches the platform version set in CamelJBang.java, then stops the process.